### PR TITLE
Fix DNS records parsing breaking on complex records with ;

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ const { login, getRecords } = require('njalla-dns')
 |-----------|-------------|
 | returns `Promise<Object[]>` | An array of records |
 | throws `Error('Not connected')` | You didn't use `login` before using this method |
+| throws `Error('Unable to parse DNS records ...')` | There was an error with the parsing code. A copy of the HTML is provided to debug or report the error (remove any sensitive data first) |
 | throws `AxiosError()` | Underlying HTTP error |
 
 ------

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const axios = require('axios')
 const cheerio = require('cheerio')
 const querystring = require('querystring')
@@ -71,10 +72,41 @@ const getRecords = async (domain, cached) => {
         return CACHED_RECORDS
     await findCookie(BASE_URL, 'csrftoken') || error('Not connected')
     const response = await get(GET_NJALLA_DOMAIN_URL(domain))
-    const matched = response.data.match(/(?<=(var records = ))\[[^;\n]+/gm)
+
+    const query = 'var records = '
+    const end = '];\n'
+    let matched = ''
+    const scriptTags = cheerio.load(response.data)(`script:contains(${query})`)
+    for (let scriptTag of scriptTags.get()) {
+        let scriptData = scriptTag.children[0].data
+
+        let startIndex = scriptData.indexOf(query)
+        if (startIndex === -1) continue
+
+        let endIndex = scriptData.indexOf(end, startIndex)
+        if (endIndex === -1) continue
+
+        // Shift start index to fetch starting at `[`
+        startIndex += query.length
+        // Shift end index to include the `]`
+        endIndex += 1
+
+        matched = scriptData.substring(startIndex, endIndex)
+        break
+    }
+
     if (!matched.length)
         return []
-    CACHED_RECORDS = JSON.parse(matched)
+    try {
+        CACHED_RECORDS = JSON.parse(matched)
+    } catch (e) {
+        const filename = 'njalla-records.html'
+        fs.writeFileSync(filename, response.data);
+        error(`Unable to parse DNS records.
+A copy of the HTML has been saved to \`${filename}\`.
+You can use this to debug, or to report an error to the library maintainer
+(first remove sensitive data if any).`);
+    }
     return CACHED_RECORDS
 }
 


### PR DESCRIPTION
There's a bit of info in the commit messages themselves.

To resume, I was encoutering JSON parsing errors when trying to fetch the DNS records for my domain. After some digging, turns out this was caused because of the Regex trying to extract the `var records` definition. Some DNS records, such as those for DKIM, can and do contain `;`, meaning the Regex would end at one of my DKIM records, and then when trying to parse it with JSON, that would fail giving a cryptic error message.

This commit tries to tackle that. It's in no way error-proof, but it's slightly more reliable. It makes use of Vheerio to first filter down to the script tag that contains the `records` definition. From there, it makes use of JavaScript's `indexOf` to try to find where the `records` declaration starts and ends. If no matches are found, it just returns `[]` as previously. If a match is found, but then gives an error when trying to `JSON.parse` it, a more human-readable error is raised. It makes a local copy of the HTML and advises people to use it to debug, and/or send it to the library maintainer after purging the sensitive data, so a better solution can be thought of.

A way more reliable solution would be to keep the Cheerio finding the declaration inside `<script>` tags, but then use a tokenizer such as `esprima` or others to parse the JavaScript and get the tokens with the declaration, and value, of `records`. However, this is more complex, and would require potentially heavy dependencies to do.

For this first iteration, to solve my usecase, while keeping the previous usages working, this works. Other solutions can from here be considered. 