### PR TITLE
Set up CI to test on push and PRs using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
GitHub Actions is the somewhat new CI provider offer from GitHub. It's an integrated alternative to other free offerings by providers such as TravisCI or CircleCI. Gitlab already had this, and you could set up your own runner on your systems, which GitHub with Actions now does as well, so I'm guessing they _borrowed_ the idea from Gitlab.

Regardless, this is just a CI system, and the easiest to set up without having to sign up for external services. The current configuration will install the dependencies for this application, and then run the AVA tests on any push to the repository, or in any pull request. This can be further configured to change when the CI is triggered (so only on push but not on PRs, for instance), or to do different things depending on the trigger type, etc. I feel like this is a good default and you can then configure it further if you have any further needs.